### PR TITLE
refact: Browser integration

### DIFF
--- a/internal/afconfig/browser.go
+++ b/internal/afconfig/browser.go
@@ -1,0 +1,84 @@
+package afconfig
+
+import (
+	"fmt"
+	neturl "net/url"
+	"os"
+	"path"
+
+	gassume "github.com/common-fate/granted/pkg/assume"
+	gbrowser "github.com/common-fate/granted/pkg/browser"
+	"github.com/common-fate/granted/pkg/forkprocess"
+	glauncher "github.com/common-fate/granted/pkg/launcher"
+)
+
+func LaunchBrowser(url string, profile string, printOnly bool) error {
+	cfg, err := NewLoadedConfig()
+	if err != nil {
+		return err
+	}
+
+	browserPath := cfg.CustomBrowserPath
+	if browserPath == "" && cfg.DefaultBrowser != gbrowser.StdoutKey {
+		return fmt.Errorf("default browser not configured. run `aws-fuzzy sso browser` to configure")
+	}
+
+	configDir, _ := cfg.ConfigFolder()
+	if err != nil {
+		return err
+	}
+
+	var l gassume.Launcher
+	finalUrl := url
+
+	switch cfg.DefaultBrowser {
+	case gbrowser.ChromeKey:
+		l = glauncher.ChromeProfile{
+			ExecutablePath: browserPath,
+			UserDataPath:   path.Join(configDir, "chromium-profiles", "1"), // held over for backwards compatibility, "1" indicates Chrome profiles
+		}
+	case gbrowser.BraveKey:
+		l = glauncher.ChromeProfile{
+			ExecutablePath: browserPath,
+			UserDataPath:   path.Join(configDir, "chromium-profiles", "2"), // held over for backwards compatibility, "2" indicates Brave profiles
+		}
+	case gbrowser.EdgeKey:
+		l = glauncher.ChromeProfile{
+			ExecutablePath: browserPath,
+			UserDataPath:   path.Join(configDir, "chromium-profiles", "3"), // held over for backwards compatibility, "3" indicates Edge profiles
+		}
+	case gbrowser.ChromiumKey:
+		l = glauncher.ChromeProfile{
+			ExecutablePath: browserPath,
+			UserDataPath:   path.Join(configDir, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
+		}
+	case gbrowser.FirefoxKey:
+		l = glauncher.Firefox{
+			ExecutablePath: browserPath,
+		}
+		finalUrl = fmt.Sprintf("ext+granted-containers:name=%s&url=%s", profile, neturl.QueryEscape(url))
+	case gbrowser.StdoutKey:
+		fmt.Println(finalUrl)
+		return nil
+	default:
+		l = glauncher.Open{}
+	}
+
+	if printOnly {
+		fmt.Println(finalUrl)
+	} else {
+		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
+		args := l.LaunchCommand(finalUrl, profile)
+		cmd, err := forkprocess.New(args...)
+		if err != nil {
+			return err
+		}
+		err = cmd.Start()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Granted was unable to open a browser session automatically: %s", err.Error())
+			fmt.Fprintf(os.Stderr, "\nOpen session manually using the following url:\n")
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/awsprofile/assumer_aws_sso.go
+++ b/internal/awsprofile/assumer_aws_sso.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/AndreZiviani/aws-fuzzy/internal/afconfig"
 	"github.com/AndreZiviani/aws-fuzzy/internal/securestorage"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -68,7 +67,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
 	var accessToken *string
 	if cachedToken == nil {
-		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, startURL, ssoTokenKey, configOpts.PrintOnly)
+		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, startURL, c.Name, configOpts.PrintOnly)
 		if err != nil {
 			return aws.Credentials{}, err
 		}
@@ -171,37 +170,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 		clio.Info(url)
 	}
 
-	/*
-		//check if sso browser path is set
-		config, err := afconfig.NewLoadedConfig()
-		if err != nil {
-			return nil, err
-		}
-
-		if config.CustomSSOBrowserPath != "" {
-			cmd := exec.Command(config.CustomSSOBrowserPath, url)
-			err = cmd.Start()
-			if err != nil {
-				// fail silently
-				clio.Debug(err.Error())
-			} else {
-				// detatch from this new process because it continues to run
-				err = cmd.Process.Release()
-				if err != nil {
-					// fail silently
-					clio.Debug(err.Error())
-				}
-			}
-		} else {
-			err = browser.OpenURL(url)
-			if err != nil {
-				// fail silently
-				clio.Debug(err.Error())
-			}
-		}
-	*/
-
-	err = afconfig.LaunchBrowser(url, profile, printOnly)
+	err = LaunchBrowser(url, profile, "sso", printOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/awsprofile/browser.go
+++ b/internal/awsprofile/browser.go
@@ -1,19 +1,21 @@
-package afconfig
+package awsprofile
 
 import (
+	"context"
 	"fmt"
 	neturl "net/url"
 	"os"
 	"path"
 
+	"github.com/AndreZiviani/aws-fuzzy/internal/afconfig"
 	gassume "github.com/common-fate/granted/pkg/assume"
 	gbrowser "github.com/common-fate/granted/pkg/browser"
 	"github.com/common-fate/granted/pkg/forkprocess"
 	glauncher "github.com/common-fate/granted/pkg/launcher"
 )
 
-func LaunchBrowser(url string, profile string, printOnly bool) error {
-	cfg, err := NewLoadedConfig()
+func LaunchBrowser(url string, profile string, flow string, printOnly bool) error {
+	cfg, err := afconfig.NewLoadedConfig()
 	if err != nil {
 		return err
 	}
@@ -26,6 +28,27 @@ func LaunchBrowser(url string, profile string, printOnly bool) error {
 	configDir, _ := cfg.ConfigFolder()
 	if err != nil {
 		return err
+	}
+
+	profiles, err := LoadProfiles()
+	if err != nil {
+		return err
+	}
+
+	p, err := profiles.LoadInitialisedProfile(context.TODO(), profile)
+	if err != nil {
+		return err
+	}
+
+	var containerName string
+	if flow == "sso" {
+		if p.AWSConfig.SSOSession != nil {
+			containerName = p.AWSConfig.SSOSession.Name
+		} else {
+			containerName = p.AWSConfig.SSOStartURL
+		}
+	} else {
+		containerName = p.Name
 	}
 
 	var l gassume.Launcher
@@ -56,7 +79,39 @@ func LaunchBrowser(url string, profile string, printOnly bool) error {
 		l = glauncher.Firefox{
 			ExecutablePath: browserPath,
 		}
-		finalUrl = fmt.Sprintf("ext+granted-containers:name=%s&url=%s", profile, neturl.QueryEscape(url))
+
+		color := ""
+		icon := ""
+		if flow == "sso" && p.AWSConfig.SSOSession != nil {
+			s := profiles.sessions[p.AWSConfig.SSOSession.Name]
+			item, err := s.RawConfig.GetKey(cfg.AppNameConfig + "_firefox_color")
+			if err == nil {
+				// https://github.com/onebytegone/granted-containers/blob/main/src/opener/parser.ts#L14
+				// allowed values:
+				// "blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple"
+				color = item.Value()
+			}
+
+			item, err = s.RawConfig.GetKey(cfg.AppNameConfig + "_firefox_icon")
+			if err == nil {
+				// https://github.com/onebytegone/granted-containers/blob/main/src/opener/parser.ts#L14
+				// allowed values:
+				// "fingerprint", "briefcase", "dollar", "cart", "circle", "gift", "vacation", "food", "fruit", "pet", "tree", "chill"
+				icon = item.Value()
+			}
+		} else {
+			item, err := p.RawConfig.GetKey(cfg.AppNameConfig + "_firefox_color")
+			if err == nil {
+				color = item.Value()
+			}
+
+			item, err = p.RawConfig.GetKey(cfg.AppNameConfig + "_firefox_icon")
+			if err == nil {
+				icon = item.Value()
+			}
+		}
+
+		finalUrl = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerName, neturl.QueryEscape(url), color, icon)
 	case gbrowser.StdoutKey:
 		fmt.Println(finalUrl)
 		return nil
@@ -68,7 +123,7 @@ func LaunchBrowser(url string, profile string, printOnly bool) error {
 		fmt.Println(finalUrl)
 	} else {
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
-		args := l.LaunchCommand(finalUrl, profile)
+		args := l.LaunchCommand(finalUrl, containerName)
 		cmd, err := forkprocess.New(args...)
 		if err != nil {
 			return err

--- a/internal/awsprofile/profiles.go
+++ b/internal/awsprofile/profiles.go
@@ -20,8 +20,9 @@ import (
 )
 
 type ConfigOpts struct {
-	Duration time.Duration
-	Args     []string
+	Duration  time.Duration
+	Args      []string
+	PrintOnly bool
 }
 
 type Profile struct {

--- a/internal/sso/configure.go
+++ b/internal/sso/configure.go
@@ -33,7 +33,7 @@ func (p *Configure) GetAccountAccess(ctx context.Context, startURL string, regio
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	ssoToken := secureSSOTokenStorage.GetValidSSOToken(startURL)
 	if ssoToken == nil {
-		ssoToken, err = awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL)
+		ssoToken, err = awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL, startURL, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sso/console.go
+++ b/internal/sso/console.go
@@ -3,17 +3,10 @@ package sso
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"os"
-	"path"
 
 	"github.com/AndreZiviani/aws-fuzzy/internal/afconfig"
 	"github.com/AndreZiviani/aws-fuzzy/internal/tracing"
-	gassume "github.com/common-fate/granted/pkg/assume"
-	gbrowser "github.com/common-fate/granted/pkg/browser"
 	gconsole "github.com/common-fate/granted/pkg/console"
-	"github.com/common-fate/granted/pkg/forkprocess"
-	glauncher "github.com/common-fate/granted/pkg/launcher"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -38,7 +31,7 @@ func (p *Console) OpenBrowser(ctx context.Context) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ssorolecreds")
 	defer span.Finish()
 
-	login := Login{Profile: p.Profile, NoCache: p.NoCache}
+	login := Login{Profile: p.Profile, NoCache: p.NoCache, Url: p.Url}
 	login.LoadProfiles()
 	profile, err := login.GetProfile(p.Profile)
 	if err != nil {
@@ -65,80 +58,5 @@ func (p *Console) OpenBrowser(ctx context.Context) error {
 		return err
 	}
 
-	cfg, err := afconfig.NewLoadedConfig()
-	if err != nil {
-		return err
-	}
-
-	if cfg.DefaultBrowser == gbrowser.FirefoxKey {
-		session = fmt.Sprintf("ext+granted-containers:name=%s&url=%s", p.Profile, url.QueryEscape(session))
-	}
-
-	if p.Url {
-		fmt.Println(session)
-		return nil
-	}
-
-	return p.LaunchConsoleSession(session)
-}
-
-func (p *Console) LaunchConsoleSession(con string) error {
-	cfg, err := afconfig.NewLoadedConfig()
-	if err != nil {
-		return err
-	}
-
-	browserPath := cfg.CustomBrowserPath
-	if browserPath == "" {
-		return fmt.Errorf("default browser not configured. run `aws-fuzzy sso browser` to configure")
-	}
-
-	configDir, _ := cfg.ConfigFolder()
-	if err != nil {
-		return err
-	}
-
-	var l gassume.Launcher
-	switch cfg.DefaultBrowser {
-	case gbrowser.ChromeKey:
-		l = glauncher.ChromeProfile{
-			ExecutablePath: browserPath,
-			UserDataPath:   path.Join(configDir, "chromium-profiles", "1"), // held over for backwards compatibility, "1" indicates Chrome profiles
-		}
-	case gbrowser.BraveKey:
-		l = glauncher.ChromeProfile{
-			ExecutablePath: browserPath,
-			UserDataPath:   path.Join(configDir, "chromium-profiles", "2"), // held over for backwards compatibility, "2" indicates Brave profiles
-		}
-	case gbrowser.EdgeKey:
-		l = glauncher.ChromeProfile{
-			ExecutablePath: browserPath,
-			UserDataPath:   path.Join(configDir, "chromium-profiles", "3"), // held over for backwards compatibility, "3" indicates Edge profiles
-		}
-	case gbrowser.ChromiumKey:
-		l = glauncher.ChromeProfile{
-			ExecutablePath: browserPath,
-			UserDataPath:   path.Join(configDir, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
-		}
-	case gbrowser.FirefoxKey:
-		l = glauncher.Firefox{
-			ExecutablePath: browserPath,
-		}
-	default:
-		l = glauncher.Open{}
-	}
-
-	// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
-	args := l.LaunchCommand(con, p.Profile)
-	cmd, err := forkprocess.New(args...)
-	if err != nil {
-		return err
-	}
-	err = cmd.Start()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Granted was unable to open a browser session automatically: %s", err.Error())
-		fmt.Fprintf(os.Stderr, "\nOpen session manually using the following url:\n")
-		return err
-	}
-	return nil
+	return afconfig.LaunchBrowser(session, p.Profile, p.Url)
 }

--- a/internal/sso/console.go
+++ b/internal/sso/console.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/AndreZiviani/aws-fuzzy/internal/afconfig"
+	"github.com/AndreZiviani/aws-fuzzy/internal/awsprofile"
 	"github.com/AndreZiviani/aws-fuzzy/internal/tracing"
 	gconsole "github.com/common-fate/granted/pkg/console"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -58,5 +58,5 @@ func (p *Console) OpenBrowser(ctx context.Context) error {
 		return err
 	}
 
-	return afconfig.LaunchBrowser(session, p.Profile, p.Url)
+	return awsprofile.LaunchBrowser(session, p.Profile, "console", p.Url)
 }

--- a/internal/sso/login.go
+++ b/internal/sso/login.go
@@ -93,7 +93,7 @@ func (p *Login) GetCredentials(ctx context.Context) (*aws.Credentials, error) {
 	cachedToken := credstore.GetValidSSOToken(ssoTokenKey)
 	if cachedToken == nil {
 		cfg, err := NewAwsConfig(ctx, nil)
-		newSSOToken, err := awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL, ssoTokenKey, p.Url)
+		newSSOToken, err := awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL, profile.Name, p.Url)
 		if err != nil {
 			return &aws.Credentials{}, err
 		}

--- a/internal/sso/login.go
+++ b/internal/sso/login.go
@@ -93,19 +93,12 @@ func (p *Login) GetCredentials(ctx context.Context) (*aws.Credentials, error) {
 	cachedToken := credstore.GetValidSSOToken(ssoTokenKey)
 	if cachedToken == nil {
 		cfg, err := NewAwsConfig(ctx, nil)
-		newSSOToken, err := awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL)
+		newSSOToken, err := awsprofile.SSODeviceCodeFlowFromStartUrl(ctx, cfg, startURL, ssoTokenKey, p.Url)
 		if err != nil {
 			return &aws.Credentials{}, err
 		}
 
 		credstore.StoreSSOToken(ssoTokenKey, *newSSOToken)
-	}
-
-	if p.Url {
-		err := p.oidcUrl(ctx)
-		if err != nil {
-			return &aws.Credentials{}, err
-		}
 	}
 
 	if p.NoCache {
@@ -151,7 +144,7 @@ func (p *Login) GetCredentials(ctx context.Context) (*aws.Credentials, error) {
 		creds, err = p.LoginMFA(ctx)
 	} else {
 		// Everything else
-		creds, err = profile.AssumeTerminal(ctx, awsprofile.ConfigOpts{Duration: time.Hour})
+		creds, err = profile.AssumeTerminal(ctx, awsprofile.ConfigOpts{Duration: time.Hour, PrintOnly: p.Url})
 	}
 
 	if err != nil {


### PR DESCRIPTION
- Use aws-fuzzy browser logic in OIDC authentication flow
- Add support for configuring firefox containers icons and colors per profile/session